### PR TITLE
Begin prep for fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 java_card_kit-2_2_2-linux.zip
 /test/*.pem
 /test/*.ebox
+/dist/
+ext/*.jar

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/ant"]
-	path = ext/ant
-	url = https://github.com/martinpaljak/ant-javacard.git

--- a/README.adoc
+++ b/README.adoc
@@ -8,8 +8,9 @@
 
 ## About
 
-This is an attempt at making a PIV (NIST SP 800-73-4) compatible JavaCard
-applet. Target is JavaCard 2.2.2+, with 1-3k of transient memory.
+This is the Open Physical Working Group fork of PivApplet by arekinath.
+
+This applet supports JavaCard 2.2.2+, with 1-3k of transient memory.
 
 ## Current status
 
@@ -41,74 +42,6 @@ What doesn't work:
  * YubicoPIV touch policy
    - No standard JavaCard APIs for accessing GPIO or sensors so this is
      probably not happening.
-
-## Installing
-
-The pre-built `.cap` files for each release can be found on the
-https://github.com/arekinath/pivapplet/releases[project release page].
-
-You can use the
-https://github.com/martinpaljak/GlobalPlatformPro[Global Platform] command-line
-tool (`gp`) to upload the applet to your JavaCard:
-
------
-$ gp -install PivApplet.cap
-CAP loaded
------
-
-Now you have a PIV card ready to initialise. It's easiest to do the
-initialisation with the
-https://developers.yubico.com/yubico-piv-tool/[`yubico-piv-tool`]:
-
------
-$ yubico-piv-tool -r '' -a list-readers
-Alcor Micro AU9560 00 00
-Yubico Yubikey 4 OTP+U2F+CCID 01 00
-
-$ yubico-piv-tool -r Alcor -a generate -s 9e > pubkey-9e.pem
-Successfully generated a new private key.
-
-$ yubico-piv-tool -r Alcor -a selfsign-certificate -s 9e \
-    -S '/CN=test' < pubkey-9e.pem > cert-9e.pem
-Successfully generated a new self signed certificate.
-
-$ yubico-piv-tool -r Alcor -a import-certificate -s 9e < cert-9e.pem
-Successfully imported a new certificate.
------
-
-Now your PIV token is set up with a self-signed Card Authentication (`9e`)
-key. You can generate keys and certificates in the other slots in a similar
-fashion (remember that most other slots default to requiring a PIN entry,
-which you have to do with `-a verify-pin -a selfsign-certificate ...` when
-using `yubico-piv-tool`).
-
-Sample output of `yubico-piv-tool -a status`:
-
------
-CHUID:	301900000000000000000000000000000000000000000000000000341047132924dfd1f7581290d383781dc81a350832303530303130313e00fe00
-CCC:	f015a000000116ff02b8907468b1e6d143231c5c7c452df10121f20121f300f400f50110f600f700fa00fb00fc00fd00fe00
-Slot 9e:
-	Algorithm:	RSA2048
-	Subject DN:	CN=test
-	Issuer DN:	CN=test
-	Fingerprint:	acbc68b8ec8a25432a296801e4deb375a14b4d78f35016f8729a7c481040eb9a
-	Not Before:	Jun 19 05:33:06 2017 GMT
-	Not After:	Jun 19 05:33:06 2018 GMT
-PIN tries left:	5
------
-
-## Default admin key & PINs
-
-Default PIN:: `123456`
-Default PUK:: `12345678`
-Default card administration (`9B`) key:: `01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08 ...`
-
-(This is the default used by Yubikeys, so that the `yubico-piv-tool` will
-work with PivApplet.)
-
-Note that if 3DES admin key support is disabled, the default card
-administration key will be AES-128 instead (with the first 16 bytes of the
-default 3DES key as its value).
 
 ## ECDSA hash-on-card extension
 
@@ -154,26 +87,17 @@ it there to decide whether to attempt use hash-on-card or not.
 
 We use https://github.com/martinpaljak/ant-javacard[ant-javacard] for builds.
 
+Builds require Java 8.
+
 -----
-$ git clone https://github.com/arekinath/PivApplet
+$ git clone https://github.com/OpenPhysical/PivApplet
 ...
 
-$ cd PivApplet
-$ git submodule init && git submodule update
-...
-
-$ export JC_HOME=/path/to/jckit-2.2.2
-$ ant
+$ export JC_HOME=/path/to/JDK_8_HOME
+$ JC_SDKS=../oracle_javacard_sdks ./build.rb
 -----
 
-The capfile will be output in the `./bin` directory, along with the `.class`
-files (which can be used with jCardSim).
-
-You can also download pre-built capfiles from the
-https://github.com/arekinath/PivApplet/releases[releases page] here on GitHub.
-
-The applet can be configured to suit different cards or needs by adjusting
-the feature flags in `build.xml` before running `ant`.
+The capfiles will be output in the `./bin` directory.
 
 Currently available feature flags:
 

--- a/build.rb
+++ b/build.rb
@@ -3,7 +3,7 @@
 require 'nokogiri'
 require 'fileutils'
 
-VER = "0.9.0"
+VER = "1.0.0"
 
 FLAGS = {
 	'R' => 'PIV_SUPPORT_RSA',
@@ -17,6 +17,14 @@ FLAGS = {
 	'a' => 'PIV_SUPPORT_AES',
 	'D' => 'PIV_SUPPORT_3DES'
 }
+
+puts "PIVApplet Build Started..."
+if (ENV['JC_SDKS'].nil?)
+	puts "ERROR: SDK path must be set"
+	exit (1)
+else
+	puts "SDK Path: " + ENV['JC_SDKS']
+end
 
 $xmlbase = Nokogiri::XML(File.open('build.xml'))
 FLAGS.each do |_,fl|
@@ -46,11 +54,6 @@ end
 
 `rm -fr dist`
 `mkdir dist`
-build(VER, 'jc221', 'RESaD')
-build(VER, 'jc221', 'RESAaD')
-build(VER, 'jc221', 'RESLaD')
-build(VER, 'jc221', 'RESLD')
-
 build(VER, 'jc222', 'RESAaD')
 build(VER, 'jc222', 'RESAxaD')
 build(VER, 'jc222', 'REAxaD')

--- a/build.xml
+++ b/build.xml
@@ -38,7 +38,7 @@
     around which slots and keys are allowed to be used over the contactless
     interface. If false, allow anything to be used over contactless.
   -->
-  <property name="PIV_STRICT_CONTACTLESS" value="true"/>
+  <property name="PIV_STRICT_CONTACTLESS" value="false"/>
   <!--
     YKPIV_ATTESTATION: whether to build support for YubicoPIV attestation.
     Without this, the attestation slots and commands will all return
@@ -76,9 +76,9 @@
 
   <target name="dist" depends="preprocess" description="generate the distribution">
     <tstamp/>
-    <ant dir="ext/ant"/>
+    <get src="https://github.com/martinpaljak/ant-javacard/releases/latest/download/ant-javacard.jar" dest="ext/" skipexisting="true"/>
     <!-- Create the distribution directory -->
-    <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ext/ant/ant-javacard.jar"/>
+    <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ext/ant-javacard.jar"/>
     <javacard>
       <cap aid="a0:00:00:03:08:00:00:10" output="bin/PivApplet.cap" sources="src-gen" classes="bin" version="1.0">
         <applet class="net.cooperi.pivapplet.PivApplet" aid="a0:00:00:03:08:00:00:10:00:01:00"/>

--- a/src/net/cooperi/pivapplet/PivApplet.java
+++ b/src/net/cooperi/pivapplet/PivApplet.java
@@ -49,8 +49,8 @@ public class PivApplet extends Applet
 	};
 
 	private static final byte[] APP_NAME = {
-	    'P', 'i', 'v', 'A', 'p', 'p', 'l', 'e', 't', ' ',
-	    'v', '0', '.', '9', '.', '0', '/',
+	    'O', 'p', 'e', 'n', 'P', 'h', 'y', 's', 'i', 'c', 'a', 'l', ' ',
+	    'v', '1', '.', '0', '.', '0', '/',
 //#if PIV_SUPPORT_RSA
 	    'R',
 //#endif
@@ -88,7 +88,7 @@ public class PivApplet extends Applet
 
 	private static final byte[] APP_URI = {
 	    'g', 'i', 't', 'h', 'u', 'b', '.', 'c', 'o', 'm', '/',
-	    'a', 'r', 'e', 'k', 'i', 'n', 'a', 't', 'h', '/',
+	    'O', 'p', 'e', 'n', 'P', 'h', 'y', 's', 'i', 'c', 'a', 'l', '/',
 	    'P', 'i', 'v', 'A', 'p', 'p', 'l', 'e', 't'
 	};
 


### PR DESCRIPTION
Remove javacard 2.2.1 support
Update documentation
Bump version number in preparation for initial release
Use packaged version of ant-javacard instead of git submodule